### PR TITLE
Fix ranking issue in singularize; add test case

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -31,7 +31,6 @@ COPY --chown=user:user README.md app.py LICENSE.md /app/
 
 USER user
 
-ENV SPACY_MODEL_PATH=/app/data/de_core_news_sm
 ENV PYTHONOPTIMIZE=1
 ENV PATH="/app/.venv/bin:$PATH"
 ENV PYTHONPATH=/app

--- a/natural_language_processing/config.py
+++ b/natural_language_processing/config.py
@@ -20,7 +20,6 @@ class Settings(BaseSettings):
     CACHE_DEFAULT_TIMEOUT: int = 300
     MODEL: Literal["flair", "roberta", "roberta_german", "gliner"] = "gliner"
     EXT_OUT: bool = False
-    SPACY_MODEL_PATH: str = ""
 
     confidence_threshold: float = 0.9
 
@@ -28,12 +27,6 @@ class Settings(BaseSettings):
     def check_non_empty_string(cls, v: str, info: ValidationInfo) -> str:
         if not isinstance(v, str) or not v.strip():
             print("API_KEY is not set or empty, disabling API key requirement")
-        return v
-
-    @field_validator("SPACY_MODEL_PATH", mode="before")
-    def check_spacy_model_path(cls, v: str, info: ValidationInfo) -> str:
-        if not isinstance(v, str) or not v.strip():
-            print("SPACY_MODEL_PATH is not set or empty. Cannot use spacy for entity post processing.")
         return v
 
 

--- a/natural_language_processing/gliner.py
+++ b/natural_language_processing/gliner.py
@@ -36,7 +36,7 @@ def transform_result(entities: list[dict]) -> list[dict]:
 class GLiNERModel(Predictor):
     def __init__(self):
         self.general_model = GLiNER.from_pretrained("llinauer/gliner_de_en_news")
-        self.general_labels = ["Person", "Location", "Organization", "Event", "Product", "Address", "URL"]
+        self.general_labels = ["Person", "Location", "Organization", "Product", "Address"]
         self.cybersec_model = GLiNER.from_pretrained("selfconstruct3d/AITSecNER", load_tokenizer=True)
         self.cybersec_labels = ["CLICommand/CodeSnippet", "CON", "GROUP", "MALWARE", "SECTOR", "TACTIC", "TECHNIQUE", "TOOL"]
 

--- a/natural_language_processing/gliner.py
+++ b/natural_language_processing/gliner.py
@@ -2,7 +2,6 @@ from gliner import GLiNER
 from natural_language_processing.config import Config
 from natural_language_processing.predictor import Predictor
 from natural_language_processing.post_process import clean_entities
-import langdetect
 
 
 def map_cybersec_entities(cybersec_entities: list[dict[str, str]]) -> list[dict[str, str]]:
@@ -54,7 +53,7 @@ class GLiNERModel(Predictor):
         if not entities:
             return [] if extended_output else {}
 
-        entities = clean_entities(transform_result(entities), langdetect.detect(text))
+        entities = clean_entities(transform_result(entities), text)
 
         if extended_output:
             out_list = []

--- a/natural_language_processing/post_process.py
+++ b/natural_language_processing/post_process.py
@@ -1,21 +1,6 @@
 import re
-import inflect
-import spacy
-from pathlib import Path
-from huggingface_hub import snapshot_download
-
-from natural_language_processing.log import logger
-from natural_language_processing.config import Config
-
-NLP_DE = None
-
-
-def get_nlp_de():
-    global NLP_DE
-    if NLP_DE is None:
-        NLP_DE = load_spacy_model(Config.SPACY_MODEL_PATH)
-    return NLP_DE
-
+import simplemma
+from collections import defaultdict
 
 DEMONYM_TO_COUNTRY_EN = {
     "russian": "russia",
@@ -101,85 +86,6 @@ DEMONYM_TO_COUNTRY_DE = {
     "litauisch": "litauen",
 }
 
-IRREGULAR_PLURALS = {
-    "people": "person",
-    "men": "man",
-    "women": "woman",
-    "children": "child",
-    "mice": "mouse",
-    "geese": "goose",
-    "teeth": "tooth",
-    "feet": "foot",
-    "oxen": "ox",
-    "lice": "louse",
-    "dice": "die",
-    "cacti": "cactus",
-    "fungi": "fungus",
-    "nuclei": "nucleus",
-    "alumni": "alumnus",
-    "syllabi": "syllabus",
-    "indices": "index",
-    "matrices": "matrix",
-    "criteria": "criterion",
-    "phenomena": "phenomenon",
-    "appendices": "appendix",
-    "theses": "thesis",
-    "analyses": "analysis",
-    "diagnoses": "diagnosis",
-    "crises": "crisis",
-    "data": "datum",
-    "media": "medium",
-    "barracks": "barracks",
-    "police": "police",
-    "behörden": "behörde",
-    "unternehmen": "unternehmen",
-    "universitäten": "universität",
-    "parteien": "partei",
-    "regierungen": "regierung",
-    "städte": "stadt",
-    "länder": "land",
-    "regionen": "region",
-    "zeiten": "zeit",
-    "männer": "mann",
-    "frauen": "frau",
-    "häuser": "haus",
-    "bücher": "buch",
-    "lieder": "lied",
-    "bäume": "baum",
-    "mäuse": "maus",
-    "füße": "fuß",
-    "kühe": "kuh",
-    "eier": "ei",
-    "wörter": "wort",
-    "worte": "wort",
-    "bilder": "bild",
-    "töchter": "tochter",
-    "brüder": "bruder",
-    "väter": "vater",
-    "mütter": "mutter",
-}
-
-
-def load_spacy_model(model_path: str) -> spacy.language.Language | None:
-    p = Path(model_path)
-    if not p.exists():
-        download_spacy_model(model_path)
-    try:
-        return spacy.load(model_path)
-    except Exception as e:
-        logger.error(f"Cannot load spacy model from {model_path}: {e}")
-        return None
-
-
-def download_spacy_model(model_path: str):
-    # try to create parent path of model_path
-    Path(model_path).parent.mkdir(exist_ok=True, parents=True)
-    try:
-        logger.info("Downloading spacy model spacy/de_core_news_sm")
-        snapshot_download("spacy/de_core_news_sm", local_dir=model_path)
-    except Exception as e:
-        logger.error(f"Failed to download model to {model_path}: {e}")
-
 
 def normalize(s: str) -> str:
     # remove whitespaces and cast to lowercase
@@ -191,28 +97,6 @@ def tokenize_name(name: str) -> list[str]:
     # split on whitespace and simple punctuation
     # "ralf schumacher" -> ["ralf", "schumacher"]
     return [t for t in re.split(r"[^\wÀ-ÖØ-öø-ÿ]+", name) if t]
-
-
-def singularize_word(word: str, language: str = "en") -> str:
-    # infer singular of a word based on the language
-    # e.g. prices -> price, Katzen -> Katze
-
-    if word in IRREGULAR_PLURALS:
-        return IRREGULAR_PLURALS[word]
-
-    if language == "en":
-        singular = inflect.engine().singular_noun(word)
-        return singular or word
-
-    nlp = get_nlp_de()
-    if nlp is None:
-        return word
-
-    doc = nlp(word)
-    if not doc or len(doc) == 0:
-        return word
-    token = doc[0]
-    return token.lemma_ or word
 
 
 def normalize_de_demonym_form(word: str) -> str:
@@ -303,7 +187,7 @@ def drop_demonyms(entities: list[dict]) -> list[dict]:
 
 def deduplicate_persons(entities: list[dict]) -> list[dict]:
     # if a person is mentioned twice in a text (e.g. Willem Defoe & Defoe)
-    # -> drop the tag with only the last name
+    # -> drop the entity with only the last name
 
     persons = [e for e in entities if e["label"] == "Person"]
     singletons = []
@@ -325,59 +209,44 @@ def deduplicate_persons(entities: list[dict]) -> list[dict]:
     return [e for e in entities if id(e) not in to_drop_idcs]
 
 
-def singularize(entities: list[dict], language: str = "en") -> list[dict]:
-    # if there are multiple entities of the same "label", one as singular and one
-    # as plural -> keep the singular
-    # e.g. drone & drones -> drone
-    prepped = []
-    heads = []
+def deduplicate_by_lemma(entities: list[dict], text: str) -> list[dict]:
+    # check if multiple entities of the same "label" share the same lemma
+    # if yes, and the lemma is also in the text use the lemmatized form
+    # otherwise keep the shortest entity
+    # e.g.: LEDs -> LED, mouse & mice -> mouse, Palästen & Paläste -> Paläste (if Palast not in text)
 
-    for e in entities:
-        text = e["text"]
-        if toks := tokenize_name(text):
-            prefix = " ".join(toks[:-1]).lower()
-            head = toks[-1]
+    duplicate_candidates = defaultdict(list)
+    cleaned_entities = []
+
+    # group entities by label and lemma
+    for entity in entities:
+        entity_text = entity["text"]
+
+        # need to tokenize entity, because simplemma cannot handle multi-word entities (e.g. "apple stores")
+        lemma = " ".join([simplemma.lemmatize(token, lang=("de", "en")) for token in tokenize_name(entity_text)])
+        duplicate_candidates[(lemma, entity["label"])].append(entity)
+
+    for (lemma, _), duplicate_entities in duplicate_candidates.items():
+        if len(duplicate_entities) == 1:
+            entity = duplicate_entities[0]
         else:
-            prefix = ""
-            head = text
-        prepped.append((e, prefix, head))
-        heads.append(head)
+            entity = min(duplicate_entities, key=lambda entity: len(entity["text"]))
 
-    head_to_lemma = {h: singularize_word(h, language) for h in heads}
-    groups: dict[tuple, list[dict]] = {}
-    for e, prefix, head in prepped:
-        lemma = head_to_lemma.get(head, head)
-        key = (prefix, lemma.lower(), e.get("label"))
-        groups.setdefault(key, []).append(e)
+        if lemma in text:
+            cleaned_entities.append({**entity, "text": lemma})
+        else:
+            cleaned_entities.append(entity)
 
-    cleaned = []
-    for (prefix, lemma_lower, _), members in groups.items():
-        best = None
-        best_len = None
-
-        for e in members:
-            toks = tokenize_name(e["text"])
-            head_lower = (toks[-1] if toks else e["text"]).lower()
-            if head_lower == lemma_lower:
-                L = len(e["text"])
-                if best is None or L < best_len:
-                    best = e
-                    best_len = L
-        if best is None:
-            best = members[0]  # fallback: first seen
-        cleaned.append(best)
-
-    cleaned_idx = {e["idx"] for e in cleaned}
-    return [e for e in entities if e["idx"] in cleaned_idx]
+    return cleaned_entities
 
 
-def clean_entities(entities: list[dict], lang: str = "en") -> list[dict[str, str]]:
+def clean_entities(entities: list[dict], text: str) -> list[dict[str, str]]:
     cleaned_ents = [{**e, "idx": e.get("idx", id(e))} for e in entities if e.get("text", "").strip()]
 
     cleaned_ents = deduplication(cleaned_ents)
     cleaned_ents = drop_demonyms(cleaned_ents)
     cleaned_ents = deduplicate_persons(cleaned_ents)
-    cleaned_ents = singularize(cleaned_ents, lang)
+    cleaned_ents = deduplicate_by_lemma(cleaned_ents, text)
 
     # return the cleaned entities in their original form
     keep = {e["idx"] for e in cleaned_ents}

--- a/natural_language_processing/post_process.py
+++ b/natural_language_processing/post_process.py
@@ -156,6 +156,14 @@ def map_demonym_to_country(entity: str) -> str | None:
     return None
 
 
+def remove_leading_trailing_punctuation(entities: list[dict]) -> list[dict]:
+    cleaned_entities = []
+    for entity in entities:
+        clean_entity_text = re.sub(r"(^[\s.,!;?]+|[\s.,!;?]+$)", "", entity["text"], flags=re.UNICODE)
+        cleaned_entities.append({**entity, "text": clean_entity_text})
+    return cleaned_entities
+
+
 def deduplication(entities: list[dict]) -> list[dict]:
     # remove duplicates with different casing from same category
     unique = {}
@@ -243,6 +251,7 @@ def deduplicate_by_lemma(entities: list[dict], text: str) -> list[dict]:
 def clean_entities(entities: list[dict], text: str) -> list[dict[str, str]]:
     cleaned_ents = [{**e, "idx": e.get("idx", id(e))} for e in entities if e.get("text", "").strip()]
 
+    cleaned_ents = remove_leading_trailing_punctuation(cleaned_ents)
     cleaned_ents = deduplication(cleaned_ents)
     cleaned_ents = drop_demonyms(cleaned_ents)
     cleaned_ents = deduplicate_persons(cleaned_ents)

--- a/natural_language_processing/predictor_factory.py
+++ b/natural_language_processing/predictor_factory.py
@@ -1,8 +1,5 @@
-from pathlib import Path
-
 from natural_language_processing.config import Config
 from natural_language_processing.predictor import Predictor
-from natural_language_processing.post_process import download_spacy_model
 
 
 class PredictorFactory:
@@ -13,9 +10,6 @@ class PredictorFactory:
     """
 
     def __new__(cls, *args, **kwargs) -> Predictor:
-        if not Path(Config.SPACY_MODEL_PATH).exists():
-            download_spacy_model(Config.SPACY_MODEL_PATH)
-
         if Config.MODEL == "flair":
             from natural_language_processing.flair_ner import FlairNER
 

--- a/natural_language_processing/tests/conftest.py
+++ b/natural_language_processing/tests/conftest.py
@@ -3,10 +3,6 @@ import pytest
 from natural_language_processing.roberta_ner import RobertaNER
 from natural_language_processing.flair_ner import FlairNER
 from natural_language_processing.gliner import GLiNERModel
-from natural_language_processing.config import Config
-
-
-Config.SPACY_MODEL_PATH = "/tmp/natural_language_processing_test/de_core_news_sm"
 
 
 @pytest.fixture(scope="session")
@@ -209,7 +205,7 @@ def extended_output_schema():
 
 @pytest.fixture
 def entities_en():
-    return [
+    entities = [
         {"idx": 1, "text": "Russia", "label": "Location"},
         {"idx": 2, "text": "russian", "label": "Location"},
         {"idx": 3, "text": "Willem Defoe", "label": "Person"},
@@ -217,11 +213,17 @@ def entities_en():
         {"idx": 5, "text": "prices", "label": "Misc"},
         {"idx": 6, "text": "price", "label": "Misc"},
     ]
+    text = (
+        "Russia was mentioned in the article, and a russian diplomat was quoted. "
+        "The actor Willem Defoe gave a speech, and later only Defoe was mentioned. "
+        "The prices have been falling, but the word price is also common in the text."
+    )
+    return entities, text
 
 
 @pytest.fixture
 def entities_de():
-    return [
+    entities = [
         {"idx": 1, "text": "Spanien", "label": "Location"},
         {"idx": 2, "text": "Spanier", "label": "Location"},
         {"idx": 3, "text": "Russland", "label": "Location"},
@@ -231,3 +233,10 @@ def entities_de():
         {"idx": 7, "text": "Burroughs", "label": "Person"},
         {"idx": 8, "text": "William S. Burroughs", "label": "Person"},
     ]
+    text = (
+        "Spanien wurde in dem Bericht erwähnt, ebenso ein Spanier. "
+        "Russland ist ein großes Land, und die russischen Beziehungen wurden diskutiert. "
+        "Die Katzen spielten im Garten, aber eine einzelne Katze schlief auf dem Sofa. "
+        "Der Autor William S. Burroughs schrieb viele Bücher, später wurde nur Burroughs genannt."
+    )
+    return entities, text

--- a/natural_language_processing/tests/test_post_process.py
+++ b/natural_language_processing/tests/test_post_process.py
@@ -282,6 +282,17 @@ def test_deduplicate_persons(entities, expected):
                 {"idx": 2, "text": "Technische Universität"},
             ],
         ),
+        (
+            "en",
+            [
+                {"idx": 1, "text": "Marshmallow", "label": "Product"},
+                {"idx": 2, "text": "Marshmallow", "label": "Organization"},
+            ],
+            [
+                {"idx": 1, "text": "Marshmallow", "label": "Product"},
+                {"idx": 2, "text": "Marshmallow", "label": "Organization"},
+            ],
+        ),
     ],
 )
 def test_singularize(language, entities, expected):

--- a/natural_language_processing/tests/test_post_process.py
+++ b/natural_language_processing/tests/test_post_process.py
@@ -224,62 +224,62 @@ def test_deduplicate_persons(entities, expected):
         (
             "en",
             [
-                {"idx": 1, "text": "prices"},
-                {"idx": 2, "text": "price"},
+                {"idx": 1, "text": "prices", "label": "MISC"},
+                {"idx": 2, "text": "price", "label": "MISC"},
             ],
             [
-                {"idx": 2, "text": "price"},
-            ],
-        ),
-        (
-            "en",
-            [
-                {"idx": 1, "text": "Wolves"},
-                {"idx": 2, "text": "Wolf"},
-            ],
-            [
-                {"idx": 2, "text": "Wolf"},
+                {"idx": 2, "text": "price", "label": "MISC"},
             ],
         ),
         (
             "en",
             [
-                {"idx": 1, "text": "Apple Stores"},
-                {"idx": 2, "text": "Apple Store"},
+                {"idx": 1, "text": "drones", "label": "Product"},
+                {"idx": 2, "text": "drone", "label": "Product"},
             ],
             [
-                {"idx": 2, "text": "Apple Store"},
+                {"idx": 2, "text": "drone", "label": "Product"},
             ],
         ),
         (
             "en",
             [
-                {"idx": 1, "text": "dogs"},
-                {"idx": 2, "text": "smartphones"},
+                {"idx": 1, "text": "Apple Stores", "label": "Location"},
+                {"idx": 2, "text": "Apple Store", "label": "Location"},
             ],
             [
-                {"idx": 1, "text": "dogs"},
-                {"idx": 2, "text": "smartphones"},
+                {"idx": 2, "text": "Apple Store", "label": "Location"},
+            ],
+        ),
+        (
+            "en",
+            [
+                {"idx": 1, "text": "busses", "label": "Product"},
+                {"idx": 2, "text": "smartphones", "label": "Product"},
+            ],
+            [
+                {"idx": 1, "text": "busses", "label": "Product"},
+                {"idx": 2, "text": "smartphones", "label": "Product"},
             ],
         ),
         (
             "de",
             [
-                {"idx": 1, "text": "Katzen"},
-                {"idx": 2, "text": "Katze"},
+                {"idx": 1, "text": "Schulen", "label": "Location"},
+                {"idx": 2, "text": "Schule", "label": "Location"},
             ],
             [
-                {"idx": 2, "text": "Katze"},
+                {"idx": 2, "text": "Schule", "label": "Location"},
             ],
         ),
         (
             "de",
             [
-                {"idx": 1, "text": "Technische Universitäten"},
-                {"idx": 2, "text": "Technische Universität"},
+                {"idx": 1, "text": "Technische Universitäten", "label": "Organization"},
+                {"idx": 2, "text": "Technische Universität", "label": "Organization"},
             ],
             [
-                {"idx": 2, "text": "Technische Universität"},
+                {"idx": 2, "text": "Technische Universität", "label": "Organization"},
             ],
         ),
         (

--- a/natural_language_processing/tests/test_post_process.py
+++ b/natural_language_processing/tests/test_post_process.py
@@ -72,6 +72,45 @@ def test_map_demonym_to_country(inp, expected):
     assert pc.map_demonym_to_country(inp) == expected
 
 
+@pytest.mark.parametrize(
+    "entities,expected",
+    [
+        (
+            [{"text": "Commodore 64.", "label": "Product"}],
+            [{"text": "Commodore 64", "label": "Product"}],
+        ),
+        (
+            [{"text": "Hello!", "label": "MISC"}],
+            [{"text": "Hello", "label": "MISC"}],
+        ),
+        (
+            [{"text": "?Berlin?", "label": "Location"}],
+            [{"text": "Berlin", "label": "Location"}],
+        ),
+        (
+            [{"text": "!!!Wow!!!", "label": "MISC"}],
+            [{"text": "Wow", "label": "MISC"}],
+        ),
+        (
+            [{"text": "Jean-Luc", "label": "Person"}],
+            [{"text": "Jean-Luc", "label": "Person"}],
+        ),
+        (
+            [
+                {"text": "Paris,", "label": "Location"},
+                {"text": "London;", "label": "Location"},
+            ],
+            [
+                {"text": "Paris", "label": "Location"},
+                {"text": "London", "label": "Location"},
+            ],
+        ),
+    ],
+)
+def test_remove_leading_trailing_punctuation(entities, expected):
+    assert pc.remove_leading_trailing_punctuation(entities) == expected
+
+
 def test_deduplication():
     raw_entities = [
         ("Drone", "Product"),

--- a/natural_language_processing/tests/test_post_process.py
+++ b/natural_language_processing/tests/test_post_process.py
@@ -31,31 +31,6 @@ def test_tokenize_name(name, expected):
 
 
 @pytest.mark.parametrize(
-    "word,lang,expected",
-    [
-        ("dogs", "en", "dog"),
-        ("cars", "en", "car"),
-        ("houses", "en", "house"),
-        ("men", "en", "man"),
-        ("women", "en", "woman"),
-        ("children", "en", "child"),
-        ("mice", "en", "mouse"),
-        ("wolves", "en", "wolf"),
-        ("indices", "en", "index"),
-        ("matrices", "en", "matrix"),
-        ("Katzen", "de", "Katze"),
-        ("Häuser", "de", "Haus"),
-        ("Bücher", "de", "Buch"),
-        ("Männer", "de", "Mann"),
-        ("Frauen", "de", "Frau"),
-        ("Städte", "de", "Stadt"),
-    ],
-)
-def test_singularize_word(word, lang, expected):
-    assert pc.singularize_word(word, lang) == expected
-
-
-@pytest.mark.parametrize(
     "word,expected",
     [
         ("chinesische", "chinesisch"),
@@ -219,88 +194,99 @@ def test_deduplicate_persons(entities, expected):
 
 
 @pytest.mark.parametrize(
-    "language,entities,expected",
+    "entities,text,expected",
     [
         (
-            "en",
             [
-                {"idx": 1, "text": "prices", "label": "MISC"},
-                {"idx": 2, "text": "price", "label": "MISC"},
+                {"text": "prices", "label": "MISC"},
+                {"text": "price", "label": "MISC"},
             ],
-            [
-                {"idx": 2, "text": "price", "label": "MISC"},
-            ],
+            "We track the price daily.",
+            {("price", "MISC")},
         ),
         (
-            "en",
             [
-                {"idx": 1, "text": "drones", "label": "Product"},
-                {"idx": 2, "text": "drone", "label": "Product"},
+                {"text": "drones", "label": "Product"},
+                {"text": "drone", "label": "Product"},
             ],
-            [
-                {"idx": 2, "text": "drone", "label": "Product"},
-            ],
+            "Multiple drones were sent out to detect unusual activity of the local wildlife.",
+            {("drone", "Product")},
         ),
         (
-            "en",
-            [
-                {"idx": 1, "text": "Apple Stores", "label": "Location"},
-                {"idx": 2, "text": "Apple Store", "label": "Location"},
-            ],
-            [
-                {"idx": 2, "text": "Apple Store", "label": "Location"},
-            ],
+            [{"text": "Apple stores", "label": "Location"}, {"text": "Apple store", "label": "Location"}],
+            "Your local Apple stores will be restocked by the end of the week.",
+            {("Apple store", "Location")},
         ),
         (
-            "en",
             [
-                {"idx": 1, "text": "busses", "label": "Product"},
-                {"idx": 2, "text": "smartphones", "label": "Product"},
+                {"text": "Paläste", "label": "Location"},
             ],
-            [
-                {"idx": 1, "text": "busses", "label": "Product"},
-                {"idx": 2, "text": "smartphones", "label": "Product"},
-            ],
+            "Die Paläste wurden renoviert.",
+            {("Paläste", "Location")},
         ),
         (
-            "de",
             [
-                {"idx": 1, "text": "Schulen", "label": "Location"},
-                {"idx": 2, "text": "Schule", "label": "Location"},
+                {"text": "Katzen", "label": "MISC"},
+                {"text": "Katze", "label": "MISC"},
             ],
-            [
-                {"idx": 2, "text": "Schule", "label": "Location"},
-            ],
+            "Mehrere Katzen kamen zusammen um sich über die Aufnahme einer neuen Katze zu beraten.",
+            {("Katze", "MISC")},
         ),
         (
-            "de",
             [
-                {"idx": 1, "text": "Technische Universitäten", "label": "Organization"},
-                {"idx": 2, "text": "Technische Universität", "label": "Organization"},
+                {"text": "Marshmallow", "label": "Product"},
+                {"text": "Marshmallow", "label": "Organization"},
             ],
-            [
-                {"idx": 2, "text": "Technische Universität", "label": "Organization"},
-            ],
+            "Marshmallows by the company aptly named Marshmallow, are really good.",
+            {("Marshmallow", "Product"), ("Marshmallow", "Organization")},
         ),
         (
-            "en",
             [
-                {"idx": 1, "text": "Marshmallow", "label": "Product"},
-                {"idx": 2, "text": "Marshmallow", "label": "Organization"},
+                {"text": "Nachbarn", "label": "Person"},
+                {"text": "Nachbar", "label": "Person"},
             ],
+            "Die Nachbarn störten schon wieder einmal die Nachtruhe",
+            {("Nachbar", "Person")},
+        ),
+        (
             [
-                {"idx": 1, "text": "Marshmallow", "label": "Product"},
-                {"idx": 2, "text": "Marshmallow", "label": "Organization"},
+                {"text": "Technischen Universitäten", "label": "Organization"},
+                {"text": "Technische Universität", "label": "Organization"},
             ],
+            "Die Technischen Universitäten sind von zweifelhaftem Ruf. Überhaupt die Technische Universität Wels.",
+            {("Technische Universität", "Organization")},
+        ),
+        (
+            [{"text": "geese", "label": "Animal"}],
+            "Many geese form a gaggle.",
+            {("geese", "Animal")},
+        ),
+        (
+            [{"text": "Handy", "label": "Product"}, {"text": "Handy", "label": "Product"}],
+            "Bundesweiter Warntag: Donnerstag bimmeln auch die Handys wieder. Am bundesweiten Warntag werden wieder Warnmeldungen per Handy, Radio und über weitere Kanäle verbreitet",
+            {("Handy", "Product")},
+        ),
+        (
+            [{"text": "Premium-Smartphones", "label": "Product"}, {"text": "Premium-Smartphone", "label": "Product"}],
+            "Premium-Smartphones sind immer noch heiß begehrt. Jedoch erhält man für um die 600 euro mittlerweile auch ein Premium-Smartphone aus dem Vorjahr.",
+            {("Premium-Smartphone", "Product")},
+        ),
+        (
+            [{"text": "Fliegers", "label": "Product"}],
+            "Vor Kurzem war das GPS des Fliegers von der Leyens betroffen.",
+            {("Flieger", "Product")},
         ),
     ],
 )
-def test_singularize(language, entities, expected):
-    assert pc.singularize(entities, language) == expected
+def test_deduplicate_by_lemma(entities, text, expected):
+    result = pc.deduplicate_by_lemma(entities, text)
+    got = {(e["text"], e["label"]) for e in result}
+    assert got == expected
 
 
 def test_clean_entities_en(entities_en):
-    cleaned = pc.clean_entities(entities_en, lang="en")
+    entities, text = entities_en
+    cleaned = pc.clean_entities(entities, text)
 
     assert any(e["text"] == "Russia" for e in cleaned)
     assert all(e["text"] != "russian" for e in cleaned)
@@ -313,7 +299,8 @@ def test_clean_entities_en(entities_en):
 
 
 def test_clean_entities_de(entities_de):
-    cleaned = pc.clean_entities(entities_de, lang="de")
+    entities, text = entities_de
+    cleaned = pc.clean_entities(entities, text)
 
     assert any(e["text"] == "Spanien" for e in cleaned)
     assert all(e["text"] != "Spanier" for e in cleaned)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,7 @@ dependencies = [
     "pydantic-settings",
     "python-dotenv",
     "gliner>=0.2.16",
-    "spacy>=3.7.0,<3.8.0",
-    "inflect>=7.5.0",
+    "simplemma>=1.1.2",
 ]
 dynamic = ["version"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -77,22 +77,6 @@ wheels = [
 ]
 
 [[package]]
-name = "blis"
-version = "0.7.11"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/51/8c/60c85350f2e1c9647df580083a0f6acc686ef32d1a91f4ab0c624b3ff867/blis-0.7.11.tar.gz", hash = "sha256:cec6d48f75f7ac328ae1b6fbb372dde8c8a57c89559172277f66e01ff08d4d42", size = 2897107, upload-time = "2023-09-22T06:28:25.103Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/12/90897bc489626cb71e51ce8bb89e492fabe96a57811e53159c0f74ae90ec/blis-0.7.11-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:dadf8713ea51d91444d14ad4104a5493fa7ecc401bbb5f4a203ff6448fadb113", size = 6121528, upload-time = "2023-09-22T06:27:39.451Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/5d/67a3f6b6108c39d3fd1cf55a7dca9267152190dad419c9de6d764b3708ca/blis-0.7.11-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5bcdaf370f03adaf4171d6405a89fa66cb3c09399d75fc02e1230a78cd2759e4", size = 1105039, upload-time = "2023-09-22T06:27:41.143Z" },
-    { url = "https://files.pythonhosted.org/packages/03/62/0d214dde0703863ed2d3dabb3f10606f7f55ac4eb07a52c3906601331b63/blis-0.7.11-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7de19264b1d49a178bf8035406d0ae77831f3bfaa3ce02942964a81a202abb03", size = 1701009, upload-time = "2023-09-22T06:27:42.672Z" },
-    { url = "https://files.pythonhosted.org/packages/66/aa/bcbd1c6b1c7dfd717ff5c899a1c8adcc6b3e391fb7a0b00fdc64e4e54235/blis-0.7.11-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8ea55c6a4a60fcbf6a0fdce40df6e254451ce636988323a34b9c94b583fc11e5", size = 10161187, upload-time = "2023-09-22T06:27:44.183Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/91/4aea63dccee6491a54c630d9817656a886e086ab97222e2d8101d8cdf894/blis-0.7.11-cp312-cp312-win_amd64.whl", hash = "sha256:5a305dbfc96d202a20d0edd6edf74a406b7e1404f4fa4397d24c68454e60b1b4", size = 6624079, upload-time = "2023-09-22T06:27:46.719Z" },
-]
-
-[[package]]
 name = "boto3"
 version = "1.36.26"
 source = { registry = "https://pypi.org/simple" }
@@ -118,15 +102,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/69/db/caa8778cf98ecbe0ad0efd7fbf673e2d036373386582e15dffff80bf16e1/botocore-1.36.26.tar.gz", hash = "sha256:4a63bcef7ecf6146fd3a61dc4f9b33b7473b49bdaf1770e9aaca6eee0c9eab62", size = 13574958, upload-time = "2025-02-21T20:28:07.114Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dd/0c/a3eeca35b22ac8f441d412881582a5f3b8665de0269baf9fdeb8e86d7f1c/botocore-1.36.26-py3-none-any.whl", hash = "sha256:4e3f19913887a58502e71ef8d696fe7eaa54de7813ff73390cd5883f837dfa6e", size = 13360675, upload-time = "2025-02-21T20:28:02.987Z" },
-]
-
-[[package]]
-name = "catalogue"
-version = "2.0.10"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/38/b4/244d58127e1cdf04cf2dc7d9566f0d24ef01d5ce21811bab088ecc62b5ea/catalogue-2.0.10.tar.gz", hash = "sha256:4f56daa940913d3f09d589c191c74e5a6d51762b3a9e37dd53b7437afd6cda15", size = 19561, upload-time = "2023-09-25T06:29:24.962Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/96/d32b941a501ab566a16358d68b6eb4e4acc373fab3c3c4d7d9e649f7b4bb/catalogue-2.0.10-py3-none-any.whl", hash = "sha256:58c2de0020aa90f4a2da7dfad161bf7b3b054c86a5f09fcedc0b2b740c109a9f", size = 17325, upload-time = "2023-09-25T06:29:23.337Z" },
 ]
 
 [[package]]
@@ -173,15 +148,6 @@ wheels = [
 ]
 
 [[package]]
-name = "cloudpathlib"
-version = "0.22.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/05/bc/d7345595a4467144b9e0b32e5eda9e4633ea6e4982262b0696935adb2229/cloudpathlib-0.22.0.tar.gz", hash = "sha256:6c0cb0ceab4f66a3a05a84055f9318fb8316cae5e096819f3f8e4be64feab6e9", size = 52304, upload-time = "2025-08-30T05:20:04.6Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f1/72/e8e53d8232e801e040f4b557ff3a453cecbb630d53ae107bd5e66a206bb9/cloudpathlib-0.22.0-py3-none-any.whl", hash = "sha256:2fdfaf5c4f85810ae8374d336d04dee371914d0e41a984695ae67308d7a5a009", size = 61520, upload-time = "2025-08-30T05:20:03.232Z" },
-]
-
-[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -200,19 +166,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/cc/c7/eed8f27100517e8c0e6b923d5f0845d0cb99763da6fdee00478f91db7325/coloredlogs-15.0.1.tar.gz", hash = "sha256:7c991aa71a4577af2f82600d8f8f3a89f936baeaf9b50a9c197da014e5bf16b0", size = 278520, upload-time = "2021-06-11T10:22:45.202Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/06/3d6badcf13db419e25b07041d9c7b4a2c331d3f4e7134445ec5df57714cd/coloredlogs-15.0.1-py2.py3-none-any.whl", hash = "sha256:612ee75c546f53e92e70049c9dbfcc18c935a2b9a53b66085ce9ef6a6e5c0934", size = 46018, upload-time = "2021-06-11T10:22:42.561Z" },
-]
-
-[[package]]
-name = "confection"
-version = "0.1.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
-    { name = "srsly" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/51/d3/57c6631159a1b48d273b40865c315cf51f89df7a9d1101094ef12e3a37c2/confection-0.1.5.tar.gz", hash = "sha256:8e72dd3ca6bd4f48913cd220f10b8275978e740411654b6e8ca6d7008c590f0e", size = 38924, upload-time = "2024-05-31T16:17:01.559Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/00/3106b1854b45bd0474ced037dfe6b73b90fe68a68968cef47c23de3d43d2/confection-0.1.5-py3-none-any.whl", hash = "sha256:e29d3c3f8eac06b3f77eb9dfb4bf2fc6bcc9622a98ca00a698e3d019c6430b14", size = 35451, upload-time = "2024-05-31T16:16:59.075Z" },
 ]
 
 [[package]]
@@ -252,21 +205,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a9/95/a3dbbb5028f35eafb79008e7522a75244477d2838f38cbb722248dabc2a8/cycler-0.12.1.tar.gz", hash = "sha256:88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c", size = 7615, upload-time = "2023-10-07T05:32:18.335Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl", hash = "sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30", size = 8321, upload-time = "2023-10-07T05:32:16.783Z" },
-]
-
-[[package]]
-name = "cymem"
-version = "2.0.11"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f2/4a/1acd761fb6ac4c560e823ce40536a62f886f2d59b2763b5c3fc7e9d92101/cymem-2.0.11.tar.gz", hash = "sha256:efe49a349d4a518be6b6c6b255d4a80f740a341544bde1a807707c058b88d0bd", size = 10346, upload-time = "2025-01-16T21:50:41.045Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/67/0d74f7e9d79f934368a78fb1d1466b94bebdbff14f8ae94dd3e4ea8738bb/cymem-2.0.11-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a0fbe19ce653cd688842d81e5819dc63f911a26e192ef30b0b89f0ab2b192ff2", size = 42621, upload-time = "2025-01-16T21:49:46.585Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/d6/f7a19c63b48efc3f00a3ee8d69070ac90202e1e378f6cf81b8671f0cf762/cymem-2.0.11-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:de72101dc0e6326f6a2f73e05a438d1f3c6110d41044236d0fbe62925091267d", size = 42249, upload-time = "2025-01-16T21:49:48.973Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/60/cdc434239813eef547fb99b6d0bafe31178501702df9b77c4108c9a216f6/cymem-2.0.11-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bee4395917f6588b8ac1699499128842768b391fe8896e8626950b4da5f9a406", size = 224758, upload-time = "2025-01-16T21:49:51.382Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/68/8fa6efae17cd3b2ba9a2f83b824867c5b65b06f7aec3f8a0d0cabdeffb9b/cymem-2.0.11-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5b02f2b17d760dc3fe5812737b1ce4f684641cdd751d67761d333a3b5ea97b83", size = 227995, upload-time = "2025-01-16T21:49:54.538Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/f3/ceda70bf6447880140602285b7c6fa171cb7c78b623d35345cc32505cd06/cymem-2.0.11-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:04ee6b4041ddec24512d6e969ed6445e57917f01e73b9dabbe17b7e6b27fef05", size = 215325, upload-time = "2025-01-16T21:49:57.229Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/47/6915eaa521e1ce7a0ba480eecb6870cb4f681bcd64ced88c2f0ed7a744b4/cymem-2.0.11-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e1048dae7e627ee25f22c87bb670b13e06bc0aecc114b89b959a798d487d1bf4", size = 216447, upload-time = "2025-01-16T21:50:00.432Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/be/8e02bdd31e557f642741a06c8e886782ef78f0b00daffd681922dc9bbc88/cymem-2.0.11-cp312-cp312-win_amd64.whl", hash = "sha256:0c269c7a867d74adeb9db65fa1d226342aacf44d64b7931282f0b0eb22eb6275", size = 39283, upload-time = "2025-01-16T21:50:03.384Z" },
 ]
 
 [[package]]
@@ -482,19 +420,6 @@ wheels = [
 ]
 
 [[package]]
-name = "inflect"
-version = "7.5.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "more-itertools" },
-    { name = "typeguard" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/78/c6/943357d44a21fd995723d07ccaddd78023eace03c1846049a2645d4324a3/inflect-7.5.0.tar.gz", hash = "sha256:faf19801c3742ed5a05a8ce388e0d8fe1a07f8d095c82201eb904f5d27ad571f", size = 73751, upload-time = "2024-12-28T17:11:18.897Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8a/eb/427ed2b20a38a4ee29f24dbe4ae2dafab198674fe9a85e3d6adf9e5f5f41/inflect-7.5.0-py3-none-any.whl", hash = "sha256:2aea70e5e70c35d8350b8097396ec155ffd68def678c7ff97f51aa69c1d92344", size = 35197, upload-time = "2024-12-28T17:11:15.931Z" },
-]
-
-[[package]]
 name = "iniconfig"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -614,18 +539,6 @@ wheels = [
 ]
 
 [[package]]
-name = "langcodes"
-version = "3.5.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "language-data" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/3a/7a/5a97e327063409a5caa21541e6d08ae4a0f2da328447e9f2c7b39e179226/langcodes-3.5.0.tar.gz", hash = "sha256:1eef8168d07e51e131a2497ffecad4b663f6208e7c3ae3b8dc15c51734a6f801", size = 191030, upload-time = "2024-11-19T10:23:45.546Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c3/6b/068c2ea7a712bf805c62445bd9e9c06d7340358ef2824150eceac027444b/langcodes-3.5.0-py3-none-any.whl", hash = "sha256:853c69d1a35e0e13da2f427bb68fb2fa4a8f4fb899e0c62ad8df8d073dcfed33", size = 182974, upload-time = "2024-11-19T10:23:42.824Z" },
-]
-
-[[package]]
 name = "langdetect"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -633,18 +546,6 @@ dependencies = [
     { name = "six" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0e/72/a3add0e4eec4eb9e2569554f7c70f4a3c27712f40e3284d483e88094cc0e/langdetect-1.0.9.tar.gz", hash = "sha256:cbc1fef89f8d062739774bd51eda3da3274006b3661d199c2655f6b3f6d605a0", size = 981474, upload-time = "2021-05-07T07:54:13.562Z" }
-
-[[package]]
-name = "language-data"
-version = "1.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "marisa-trie" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/dd/ce/3f144716a9f2cbf42aa86ebc8b085a184be25c80aa453eea17c294d239c1/language_data-1.3.0.tar.gz", hash = "sha256:7600ef8aa39555145d06c89f0c324bf7dab834ea0b0a439d8243762e3ebad7ec", size = 5129310, upload-time = "2024-11-19T10:21:37.912Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/e9/5a5ffd9b286db82be70d677d0a91e4d58f7912bb8dd026ddeeb4abe70679/language_data-1.3.0-py3-none-any.whl", hash = "sha256:e2ee943551b5ae5f89cd0e801d1fc3835bb0ef5b7e9c3a4e8e17b2b214548fbf", size = 5385760, upload-time = "2024-11-19T10:21:36.005Z" },
-]
 
 [[package]]
 name = "lxml"
@@ -669,34 +570,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/69/06/128af2ed04bac99b8f83becfb74c480f1aa18407b5c329fad457e08a1bf4/lxml-5.3.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:d61ec60945d694df806a9aec88e8f29a27293c6e424f8ff91c80416e3c617645", size = 5054455, upload-time = "2025-02-10T07:46:31.665Z" },
     { url = "https://files.pythonhosted.org/packages/8a/2d/f03a21cf6cc75cdd083563e509c7b6b159d761115c4142abb5481094ed8c/lxml-5.3.1-cp312-cp312-win32.whl", hash = "sha256:f4eac0584cdc3285ef2e74eee1513a6001681fd9753b259e8159421ed28a72e5", size = 3486315, upload-time = "2025-02-10T07:46:34.919Z" },
     { url = "https://files.pythonhosted.org/packages/2b/9c/8abe21585d20ef70ad9cec7562da4332b764ed69ec29b7389d23dfabcea0/lxml-5.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:29bfc8d3d88e56ea0a27e7c4897b642706840247f59f4377d81be8f32aa0cfbf", size = 3816925, upload-time = "2025-02-10T07:46:37.285Z" },
-]
-
-[[package]]
-name = "marisa-trie"
-version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c5/e3/c9066e74076b90f9701ccd23d6a0b8c1d583feefdec576dc3e1bb093c50d/marisa_trie-1.3.1.tar.gz", hash = "sha256:97107fd12f30e4f8fea97790343a2d2d9a79d93697fe14e1b6f6363c984ff85b", size = 212454, upload-time = "2025-08-26T15:13:18.401Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/40/ee7ea61b88d62d2189b5c4a27bc0fc8d9c32f8b8dc6daf1c93a7b7ad34ac/marisa_trie-1.3.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5b7c1e7fa6c3b855e8cfbabf38454d7decbaba1c567d0cd58880d033c6b363bd", size = 173454, upload-time = "2025-08-26T15:12:12.13Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/fc/58635811586898041004b2197a085253706ede211324a53ec01612a50e20/marisa_trie-1.3.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c12b44c190deb0d67655021da1f2d0a7d61a257bf844101cf982e68ed344f28d", size = 155305, upload-time = "2025-08-26T15:12:13.374Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/98/88ca0c98d37034a3237acaf461d210cbcfeb6687929e5ba0e354971fa3ed/marisa_trie-1.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9688c7b45f744366a4ef661e399f24636ebe440d315ab35d768676c59c613186", size = 1244834, upload-time = "2025-08-26T15:12:14.795Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/5f/93b3e3607ccd693a768eafee60829cd14ea1810b75aa48e8b20e27b332c4/marisa_trie-1.3.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:99a00cab4cf9643a87977c87a5c8961aa44fff8d5dd46e00250135f686e7dedf", size = 1265148, upload-time = "2025-08-26T15:12:16.229Z" },
-    { url = "https://files.pythonhosted.org/packages/db/6e/051d7d25c7fb2b3df605c8bd782513ebbb33fddf3bae6cf46cf268cca89f/marisa_trie-1.3.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:83efc045fc58ca04c91a96c9b894d8a19ac6553677a76f96df01ff9f0405f53d", size = 2172726, upload-time = "2025-08-26T15:12:18.467Z" },
-    { url = "https://files.pythonhosted.org/packages/58/da/244d9d4e414ce6c73124cba4cc293dd140bf3b04ca18dec64c2775cca951/marisa_trie-1.3.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0b9816ab993001a7854b02a7daec228892f35bd5ab0ac493bacbd1b80baec9f1", size = 2256104, upload-time = "2025-08-26T15:12:20.168Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/f1/1a36ecd7da6668685a7753522af89a19928ffc80f1cc1dbc301af216f011/marisa_trie-1.3.1-cp312-cp312-win32.whl", hash = "sha256:c785fd6dae9daa6825734b7b494cdac972f958be1f9cb3fb1f32be8598d2b936", size = 115624, upload-time = "2025-08-26T15:12:21.233Z" },
-    { url = "https://files.pythonhosted.org/packages/35/b2/aabd1c9f1c102aa31d66633ed5328c447be166e0a703f9723e682478fd83/marisa_trie-1.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:9868b7a8e0f648d09ffe25ac29511e6e208cc5fb0d156c295385f9d5dc2a138e", size = 138562, upload-time = "2025-08-26T15:12:22.632Z" },
-]
-
-[[package]]
-name = "markdown-it-py"
-version = "4.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mdurl" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
 ]
 
 [[package]]
@@ -743,15 +616,6 @@ wheels = [
 ]
 
 [[package]]
-name = "mdurl"
-version = "0.1.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
-]
-
-[[package]]
 name = "more-itertools"
 version = "10.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -783,21 +647,6 @@ wheels = [
 ]
 
 [[package]]
-name = "murmurhash"
-version = "1.0.13"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/54/e9/02efbc6dfc2dd2085da3daacf9a8c17e8356019eceaedbfa21555e32d2af/murmurhash-1.0.13.tar.gz", hash = "sha256:737246d41ee00ff74b07b0bd1f0888be304d203ce668e642c86aa64ede30f8b7", size = 13258, upload-time = "2025-05-22T12:35:57.019Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/53/56ce2d8d4b9ab89557cb1d00ffce346b80a2eb2d8c7944015e5c83eacdec/murmurhash-1.0.13-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:bbe882e46cb3f86e092d8a1dd7a5a1c992da1ae3b39f7dd4507b6ce33dae7f92", size = 26859, upload-time = "2025-05-22T12:35:31.815Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/85/3a0ad54a61257c31496545ae6861515d640316f93681d1dd917e7be06634/murmurhash-1.0.13-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:52a33a12ecedc432493692c207c784b06b6427ffaa897fc90b7a76e65846478d", size = 26900, upload-time = "2025-05-22T12:35:34.267Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/cd/6651de26744b50ff11c79f0c0d41244db039625de53c0467a7a52876b2d8/murmurhash-1.0.13-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:950403a7f0dc2d9c8d0710f07c296f2daab66299d9677d6c65d6b6fa2cb30aaa", size = 131367, upload-time = "2025-05-22T12:35:35.258Z" },
-    { url = "https://files.pythonhosted.org/packages/50/6c/01ded95ddce33811c9766cae4ce32e0a54288da1d909ee2bcaa6ed13b9f1/murmurhash-1.0.13-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fde9fb5d2c106d86ff3ef2e4a9a69c2a8d23ba46e28c6b30034dc58421bc107b", size = 128943, upload-time = "2025-05-22T12:35:36.358Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/27/e539a9622d7bea3ae22706c1eb80d4af80f9dddd93b54d151955c2ae4011/murmurhash-1.0.13-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3aa55d62773745616e1ab19345dece122f6e6d09224f7be939cc5b4c513c8473", size = 129108, upload-time = "2025-05-22T12:35:37.864Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/84/18af5662e07d06839ad4db18ce026e6f8ef850d7b0ba92817b28dad28ba6/murmurhash-1.0.13-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:060dfef1b405cf02c450f182fb629f76ebe7f79657cced2db5054bc29b34938b", size = 129175, upload-time = "2025-05-22T12:35:38.928Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/8d/b01d3ee1f1cf3957250223b7c6ce35454f38fbf4abe236bf04a3f769341d/murmurhash-1.0.13-cp312-cp312-win_amd64.whl", hash = "sha256:a8e79627d44a6e20a6487effc30bfe1c74754c13d179106e68cc6d07941b022c", size = 24869, upload-time = "2025-05-22T12:35:40.035Z" },
-]
-
-[[package]]
 name = "natural-language-processing"
 source = { editable = "." }
 dependencies = [
@@ -806,13 +655,12 @@ dependencies = [
     { name = "gliner" },
     { name = "granian" },
     { name = "huggingface-hub" },
-    { name = "inflect" },
     { name = "networkx" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
     { name = "requests" },
     { name = "sentencepiece" },
-    { name = "spacy" },
+    { name = "simplemma" },
     { name = "torch" },
 ]
 
@@ -830,7 +678,6 @@ requires-dist = [
     { name = "gliner", specifier = ">=0.2.16" },
     { name = "granian" },
     { name = "huggingface-hub" },
-    { name = "inflect", specifier = ">=7.5.0" },
     { name = "jsonschema", marker = "extra == 'dev'" },
     { name = "networkx" },
     { name = "pydantic-settings" },
@@ -839,7 +686,7 @@ requires-dist = [
     { name = "requests" },
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "sentencepiece" },
-    { name = "spacy", specifier = ">=3.7.0,<3.8.0" },
+    { name = "simplemma", specifier = ">=1.1.2" },
     { name = "torch" },
 ]
 provides-extras = ["dev"]
@@ -1050,25 +897,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/cd/f4f2b79d20a10563d071c38b6ad14bf9c5d75a0edef877d2bed60c024247/pptree-3.1.tar.gz", hash = "sha256:4dd0ba2f58000cbd29d68a5b64bac29bcb5a663642f79404877c0059668a69f6", size = 3043, upload-time = "2020-04-15T18:28:53.362Z" }
 
 [[package]]
-name = "preshed"
-version = "3.0.10"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cymem" },
-    { name = "murmurhash" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/4d/3a/db814f67a05b6d7f9c15d38edef5ec9b21415710705b393883de92aee5ef/preshed-3.0.10.tar.gz", hash = "sha256:5a5c8e685e941f4ffec97f1fbf32694b8107858891a4bc34107fac981d8296ff", size = 15039, upload-time = "2025-05-26T15:18:33.612Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c3/14/322a4f58bc25991a87f216acb1351800739b0794185d27508ee86c35f382/preshed-3.0.10-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6e9c46933d55c8898c8f7a6019a8062cd87ef257b075ada2dd5d1e57810189ea", size = 131367, upload-time = "2025-05-26T15:18:02.408Z" },
-    { url = "https://files.pythonhosted.org/packages/38/80/67507653c35620cace913f617df6d6f658b87e8da83087b851557d65dd86/preshed-3.0.10-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5c4ebc4f8ef0114d55f2ffdce4965378129c7453d0203664aeeb03055572d9e4", size = 126535, upload-time = "2025-05-26T15:18:03.589Z" },
-    { url = "https://files.pythonhosted.org/packages/db/b1/ab4f811aeaf20af0fa47148c1c54b62d7e8120d59025bd0a3f773bb67725/preshed-3.0.10-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6ab5ab4c6dfd3746fb4328e7fbeb2a0544416b872db02903bfac18e6f5cd412f", size = 864907, upload-time = "2025-05-26T15:18:04.794Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/db/fe37c1f99cfb26805dd89381ddd54901307feceb267332eaaca228e9f9c1/preshed-3.0.10-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:40586fd96ae3974c552a7cd78781b6844ecb1559ee7556586f487058cf13dd96", size = 869329, upload-time = "2025-05-26T15:18:06.353Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/fd/efb6a6233d1cd969966f3f65bdd8e662579c3d83114e5c356cec1927b1f7/preshed-3.0.10-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a606c24cda931306b98e0edfafed3309bffcf8d6ecfe07804db26024c4f03cd6", size = 846829, upload-time = "2025-05-26T15:18:07.716Z" },
-    { url = "https://files.pythonhosted.org/packages/14/49/0e4ce5db3bf86b081abb08a404fb37b7c2dbfd7a73ec6c0bc71b650307eb/preshed-3.0.10-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:394015566f9354738be903447039e8dbc6d93ba5adf091af694eb03c4e726b1e", size = 874008, upload-time = "2025-05-26T15:18:09.364Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/17/76d6593fc2d055d4e413b68a8c87b70aa9b7697d4972cb8062559edcf6e9/preshed-3.0.10-cp312-cp312-win_amd64.whl", hash = "sha256:fd7e38225937e580420c84d1996dde9b4f726aacd9405093455c3a2fa60fede5", size = 116701, upload-time = "2025-05-26T15:18:11.905Z" },
-]
-
-[[package]]
 name = "protobuf"
 version = "5.29.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1147,15 +975,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ca/a2/ad2511ede77bb424f3939e5148a56d968cdc6b1462620d24b2a1f4ab65b4/pydantic_settings-2.8.0.tar.gz", hash = "sha256:88e2ca28f6e68ea102c99c3c401d6c9078e68a5df600e97b43891c34e089500a", size = 83347, upload-time = "2025-02-21T08:04:52.046Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/a9/3b9642025174bbe67e900785fb99c9bfe91ea584b0b7126ff99945c24a0e/pydantic_settings-2.8.0-py3-none-any.whl", hash = "sha256:c782c7dc3fb40e97b238e713c25d26f64314aece2e91abcff592fcac15f71820", size = 30746, upload-time = "2025-02-21T08:04:50.49Z" },
-]
-
-[[package]]
-name = "pygments"
-version = "2.19.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
 ]
 
 [[package]]
@@ -1306,19 +1125,6 @@ wheels = [
 [package.optional-dependencies]
 socks = [
     { name = "pysocks" },
-]
-
-[[package]]
-name = "rich"
-version = "14.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "markdown-it-py" },
-    { name = "pygments" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/fe/75/af448d8e52bf1d8fa6a9d089ca6c07ff4453d86c65c145d0a300bb073b9b/rich-14.1.0.tar.gz", hash = "sha256:e497a48b844b0320d45007cdebfeaeed8db2a4f4bcf49f15e455cfc4af11eaa8", size = 224441, upload-time = "2025-07-25T07:32:58.125Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/30/3c4d035596d3cf444529e0b2953ad0466f6049528a879d27534700580395/rich-14.1.0-py3-none-any.whl", hash = "sha256:536f5f1785986d6dbdea3c75205c473f970777b4a0d6c6dd1b696aa05a3fa04f", size = 243368, upload-time = "2025-07-25T07:32:56.73Z" },
 ]
 
 [[package]]
@@ -1479,12 +1285,12 @@ wheels = [
 ]
 
 [[package]]
-name = "shellingham"
-version = "1.5.4"
+name = "simplemma"
+version = "1.1.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/58/81fc31ae8a83a2c422ca51784825b8b2d1ebdf068e351d364fedd9707307/simplemma-1.1.2.tar.gz", hash = "sha256:8549eefc288b25262c38027ef09f2db28ee0355b2a0cc62c1a8abbe948ef72bd", size = 67189658, upload-time = "2024-11-19T16:47:09.231Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+    { url = "https://files.pythonhosted.org/packages/17/fe/cea4c2d96505425954ef281d08fc71019a42a459bfc1a9e4bc91245c9c00/simplemma-1.1.2-py3-none-any.whl", hash = "sha256:90a3060b0c59679c8a954a201c2dc8b589f3f55872b125eede5f2447fda02e8b", size = 67154845, upload-time = "2024-11-19T16:45:36.423Z" },
 ]
 
 [[package]]
@@ -1494,18 +1300,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
-]
-
-[[package]]
-name = "smart-open"
-version = "7.3.0.post1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "wrapt" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/18/2b/5e7234c68ed5bc872ad6ae77b8a421c2ed70dcb1190b44dc1abdeed5e347/smart_open-7.3.0.post1.tar.gz", hash = "sha256:ce6a3d9bc1afbf6234ad13c010b77f8cd36d24636811e3c52c3b5160f5214d1e", size = 51557, upload-time = "2025-07-03T10:06:31.271Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/08/5b/a2a3d4514c64818925f4e886d39981f1926eeb5288a4549c6b3c17ed66bb/smart_open-7.3.0.post1-py3-none-any.whl", hash = "sha256:c73661a2c24bf045c1e04e08fffc585b59af023fe783d57896f590489db66fb4", size = 61946, upload-time = "2025-07-03T10:06:29.599Z" },
 ]
 
 [[package]]
@@ -1527,80 +1321,10 @@ wheels = [
 ]
 
 [[package]]
-name = "spacy"
-version = "3.7.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "catalogue" },
-    { name = "cymem" },
-    { name = "jinja2" },
-    { name = "langcodes" },
-    { name = "murmurhash" },
-    { name = "numpy" },
-    { name = "packaging" },
-    { name = "preshed" },
-    { name = "pydantic" },
-    { name = "requests" },
-    { name = "setuptools" },
-    { name = "spacy-legacy" },
-    { name = "spacy-loggers" },
-    { name = "srsly" },
-    { name = "thinc" },
-    { name = "tqdm" },
-    { name = "typer" },
-    { name = "wasabi" },
-    { name = "weasel" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/21/1e/94e3981516db6fcd6685f058c43c3fa81805c120b04829596367dad1aa4e/spacy-3.7.5.tar.gz", hash = "sha256:a648c6cbf2acc7a55a69ee9e7fa4f22bdf69aa828a587a1bc5cfff08cf3c2dd3", size = 1274806, upload-time = "2024-06-05T07:21:56Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/c8/413225de79e71dd9ca353d597ea4890a43fa60ff98cf9615b1606680ab95/spacy-3.7.5-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:bf54c3c2425428b328b53a65913d47eb4cb27a1429aa4e8ed979ffc97d4663e0", size = 6324302, upload-time = "2024-06-05T07:21:01.604Z" },
-    { url = "https://files.pythonhosted.org/packages/60/f9/726e977c5430c44912ed97d7d965ef35d2563978b38076b254379652a522/spacy-3.7.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4145cea7f9814fa7d86b2028c2dd83e02f13f80d5ac604a400b2f7d7b26a0e8c", size = 6112434, upload-time = "2024-06-05T07:21:05.032Z" },
-    { url = "https://files.pythonhosted.org/packages/53/ff/4b3a9d3063ba98d3ce27a0c2a60e3c25e4650b7c3c7555a47179dac5c282/spacy-3.7.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:262f8ebb71f7ed5ffe8e4f384b2594b7a296be50241ce9fbd9277b5da2f46f38", size = 6065925, upload-time = "2024-06-05T07:21:07.679Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/9f/70bed4cb66629ad1fa5f45220d47bbbf6c858e70e5d69f7ca1de95dd2b92/spacy-3.7.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:faa1e2b6234ae33c0b1f8dfa5a8dcb66fb891f19231725dfcff4b2666125c250", size = 6455942, upload-time = "2024-06-05T07:21:10.303Z" },
-    { url = "https://files.pythonhosted.org/packages/58/42/b6bb76b08f4a0ccb0e2d0e4f3524acadf1ba929e2b93f90e4652d1c3cbd3/spacy-3.7.5-cp312-cp312-win_amd64.whl", hash = "sha256:07677e270a6d729453cc04b5e2247a96a86320b8845e6428d9f90f217eff0f56", size = 11673681, upload-time = "2024-06-05T07:21:13.386Z" },
-]
-
-[[package]]
-name = "spacy-legacy"
-version = "3.0.12"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d9/79/91f9d7cc8db5642acad830dcc4b49ba65a7790152832c4eceb305e46d681/spacy-legacy-3.0.12.tar.gz", hash = "sha256:b37d6e0c9b6e1d7ca1cf5bc7152ab64a4c4671f59c85adaf7a3fcb870357a774", size = 23806, upload-time = "2023-01-23T09:04:15.104Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c3/55/12e842c70ff8828e34e543a2c7176dac4da006ca6901c9e8b43efab8bc6b/spacy_legacy-3.0.12-py2.py3-none-any.whl", hash = "sha256:476e3bd0d05f8c339ed60f40986c07387c0a71479245d6d0f4298dbd52cda55f", size = 29971, upload-time = "2023-01-23T09:04:13.45Z" },
-]
-
-[[package]]
-name = "spacy-loggers"
-version = "1.0.5"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/67/3d/926db774c9c98acf66cb4ed7faf6c377746f3e00b84b700d0868b95d0712/spacy-loggers-1.0.5.tar.gz", hash = "sha256:d60b0bdbf915a60e516cc2e653baeff946f0cfc461b452d11a4d5458c6fe5f24", size = 20811, upload-time = "2023-09-11T12:26:52.323Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/78/d1a1a026ef3af911159398c939b1509d5c36fe524c7b644f34a5146c4e16/spacy_loggers-1.0.5-py3-none-any.whl", hash = "sha256:196284c9c446cc0cdb944005384270d775fdeaf4f494d8e269466cfa497ef645", size = 22343, upload-time = "2023-09-11T12:26:50.586Z" },
-]
-
-[[package]]
 name = "sqlitedict"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/12/9a/7620d1e9dcb02839ed6d4b14064e609cdd7a8ae1e47289aa0456796dd9ca/sqlitedict-2.1.0.tar.gz", hash = "sha256:03d9cfb96d602996f1d4c2db2856f1224b96a9c431bdd16e78032a72940f9e8c", size = 21846, upload-time = "2022-12-03T13:39:13.102Z" }
-
-[[package]]
-name = "srsly"
-version = "2.5.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "catalogue" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b7/e8/eb51b1349f50bac0222398af0942613fdc9d1453ae67cbe4bf9936a1a54b/srsly-2.5.1.tar.gz", hash = "sha256:ab1b4bf6cf3e29da23dae0493dd1517fb787075206512351421b89b4fc27c77e", size = 466464, upload-time = "2025-01-17T09:26:26.919Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/f6/bebc20d75bd02121fc0f65ad8c92a5dd2570e870005e940faa55a263e61a/srsly-2.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:683b54ed63d7dfee03bc2abc4b4a5f2152f81ec217bbadbac01ef1aaf2a75790", size = 636717, upload-time = "2025-01-17T09:25:40.236Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/e8/9372317a4742c70b87b413335adfcdfb2bee4f88f3faba89fabb9e6abf21/srsly-2.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:459d987130e57e83ce9e160899afbeb871d975f811e6958158763dd9a8a20f23", size = 634697, upload-time = "2025-01-17T09:25:43.605Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/00/c6a7b99ab27b051a27bd26fe1a8c1885225bb8980282bf9cb99f70610368/srsly-2.5.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:184e3c98389aab68ff04aab9095bd5f1a8e5a72cc5edcba9d733bac928f5cf9f", size = 1134655, upload-time = "2025-01-17T09:25:45.238Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/e6/861459e8241ec3b78c111081bd5efa414ef85867e17c45b6882954468d6e/srsly-2.5.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c2a3e4856e63b7efd47591d049aaee8e5a250e098917f50d93ea68853fab78", size = 1143544, upload-time = "2025-01-17T09:25:47.485Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/85/8448fe874dd2042a4eceea5315cfff3af03ac77ff5073812071852c4e7e2/srsly-2.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:366b4708933cd8d6025c13c2cea3331f079c7bb5c25ec76fca392b6fc09818a0", size = 1098330, upload-time = "2025-01-17T09:25:52.55Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/7e/04d0e1417da140b2ac4053a3d4fcfc86cd59bf4829f69d370bb899f74d5d/srsly-2.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c8a0b03c64eb6e150d772c5149befbadd981cc734ab13184b0561c17c8cef9b1", size = 1110670, upload-time = "2025-01-17T09:25:54.02Z" },
-    { url = "https://files.pythonhosted.org/packages/96/1a/a8cd627eaa81a91feb6ceab50155f4ceff3eef6107916cb87ef796958427/srsly-2.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:7952538f6bba91b9d8bf31a642ac9e8b9ccc0ccbb309feb88518bfb84bb0dc0d", size = 632598, upload-time = "2025-01-17T09:25:55.499Z" },
-]
 
 [[package]]
 name = "sympy"
@@ -1621,33 +1345,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ec/fe/802052aecb21e3797b8f7902564ab6ea0d60ff8ca23952079064155d1ae1/tabulate-0.9.0.tar.gz", hash = "sha256:0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c", size = 81090, upload-time = "2022-10-06T17:21:48.54Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/40/44/4a5f08c96eb108af5cb50b41f76142f0afa346dfa99d5296fe7202a11854/tabulate-0.9.0-py3-none-any.whl", hash = "sha256:024ca478df22e9340661486f85298cff5f6dcdba14f3813e8830015b9ed1948f", size = 35252, upload-time = "2022-10-06T17:21:44.262Z" },
-]
-
-[[package]]
-name = "thinc"
-version = "8.2.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "blis" },
-    { name = "catalogue" },
-    { name = "confection" },
-    { name = "cymem" },
-    { name = "murmurhash" },
-    { name = "numpy" },
-    { name = "packaging" },
-    { name = "preshed" },
-    { name = "pydantic" },
-    { name = "setuptools" },
-    { name = "srsly" },
-    { name = "wasabi" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/3b/2a/0e2e961e6152bedecca70e6833f6e827ee621efcee7496643242b506d54f/thinc-8.2.5.tar.gz", hash = "sha256:c2963791c934cc7fbd8f9b942d571cac79892ad11630bfca690a868c32752b75", size = 193031, upload-time = "2024-06-19T16:42:44.563Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/9d/d2ed3aef9bb75ab86c521bde58f897db6a572c9fd639448173b516269a69/thinc-8.2.5-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:9fc26697e2358c71a5fe243d52e98ae67ee1a3b314eead5031845b6d1c0d121c", size = 824150, upload-time = "2024-06-19T16:41:45.045Z" },
-    { url = "https://files.pythonhosted.org/packages/66/a6/30ed1edb2adab585b5f7d5d99e89b5be3014dcbf3f4e263997b2c2426681/thinc-8.2.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8e299d4dc41107385d6d14d8604a060825798a031cabe2b894b22f9d75d9eaad", size = 760640, upload-time = "2024-06-19T16:41:51.182Z" },
-    { url = "https://files.pythonhosted.org/packages/82/ce/aaff1f39bcc1e9a97bec5f3d20aa771c005a9faff3944fc56c7492c24466/thinc-8.2.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8a8f2f249f2be9a5ce2a81a6efe7503b68be7b57e47ad54ab28204e1f0c723b", size = 818820, upload-time = "2024-06-19T16:41:56.868Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/fa/c96b01e46e5962d02de1206e497fda2902aef2b8ffb2926d66d5f0159040/thinc-8.2.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:87e729f33c76ec6df9b375989743252ab880d79f3a2b4175169b21dece90f102", size = 865047, upload-time = "2024-06-19T16:42:06.181Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/26/306b8bedb678c52464ed00e576edf9d365fce0bcae597a333bdad9fb5d67/thinc-8.2.5-cp312-cp312-win_amd64.whl", hash = "sha256:c5f750ea2dd32ca6d46947025dacfc0f6037340c4e5f7adb9af84c75f65aa7d8", size = 1447893, upload-time = "2024-06-19T16:42:12.145Z" },
 ]
 
 [[package]]
@@ -1784,33 +1481,6 @@ wheels = [
 ]
 
 [[package]]
-name = "typeguard"
-version = "4.4.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/70/60/8cd6a3d78d00ceeb2193c02b7ed08f063d5341ccdfb24df88e61f383048e/typeguard-4.4.2.tar.gz", hash = "sha256:a6f1065813e32ef365bc3b3f503af8a96f9dd4e0033a02c28c4a4983de8c6c49", size = 75746, upload-time = "2025-02-16T16:28:26.205Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/4b/9a77dc721aa0b7f74440a42e4ef6f9a4fae7324e17f64f88b96f4c25cc05/typeguard-4.4.2-py3-none-any.whl", hash = "sha256:77a78f11f09777aeae7fa08585f33b5f4ef0e7335af40005b0c422ed398ff48c", size = 35801, upload-time = "2025-02-16T16:28:24.793Z" },
-]
-
-[[package]]
-name = "typer"
-version = "0.17.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "rich" },
-    { name = "shellingham" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/dd/82/f4bfed3bc18c6ebd6f828320811bbe4098f92a31adf4040bee59c4ae02ea/typer-0.17.3.tar.gz", hash = "sha256:0c600503d472bcf98d29914d4dcd67f80c24cc245395e2e00ba3603c9332e8ba", size = 103517, upload-time = "2025-08-30T12:35:24.05Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/e8/b3d537470e8404659a6335e7af868e90657efb73916ef31ddf3d8b9cb237/typer-0.17.3-py3-none-any.whl", hash = "sha256:643919a79182ab7ac7581056d93c6a2b865b026adf2872c4d02c72758e6f095b", size = 46494, upload-time = "2025-08-30T12:35:22.391Z" },
-]
-
-[[package]]
 name = "typing-extensions"
 version = "4.12.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1843,44 +1513,12 @@ wheels = [
 ]
 
 [[package]]
-name = "wasabi"
-version = "1.1.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ac/f9/054e6e2f1071e963b5e746b48d1e3727470b2a490834d18ad92364929db3/wasabi-1.1.3.tar.gz", hash = "sha256:4bb3008f003809db0c3e28b4daf20906ea871a2bb43f9914197d540f4f2e0878", size = 30391, upload-time = "2024-05-31T16:56:18.99Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/06/7c/34330a89da55610daa5f245ddce5aab81244321101614751e7537f125133/wasabi-1.1.3-py3-none-any.whl", hash = "sha256:f76e16e8f7e79f8c4c8be49b4024ac725713ab10cd7f19350ad18a8e3f71728c", size = 27880, upload-time = "2024-05-31T16:56:16.699Z" },
-]
-
-[[package]]
 name = "wcwidth"
 version = "0.2.13"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6c/63/53559446a878410fc5a5974feb13d31d78d752eb18aeba59c7fef1af7598/wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5", size = 101301, upload-time = "2024-01-06T02:10:57.829Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/84/fd2ba7aafacbad3c4201d395674fc6348826569da3c0937e75505ead3528/wcwidth-0.2.13-py2.py3-none-any.whl", hash = "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859", size = 34166, upload-time = "2024-01-06T02:10:55.763Z" },
-]
-
-[[package]]
-name = "weasel"
-version = "0.4.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cloudpathlib" },
-    { name = "confection" },
-    { name = "packaging" },
-    { name = "pydantic" },
-    { name = "requests" },
-    { name = "smart-open" },
-    { name = "srsly" },
-    { name = "typer" },
-    { name = "wasabi" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a7/1a/9c522dd61b52939c217925d3e55c95f9348b73a66a956f52608e1e59a2c0/weasel-0.4.1.tar.gz", hash = "sha256:aabc210f072e13f6744e5c3a28037f93702433405cd35673f7c6279147085aa9", size = 38417, upload-time = "2024-05-15T08:52:54.765Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/87/abd57374044e1f627f0a905ac33c1a7daab35a3a815abfea4e1bafd3fdb1/weasel-0.4.1-py3-none-any.whl", hash = "sha256:24140a090ea1ac512a2b2f479cc64192fd1d527a7f3627671268d08ed5ac418c", size = 50270, upload-time = "2024-05-15T08:52:52.977Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Replace spacy and inflect with simplemma (https://github.com/adbar/simplemma)
It can handle german and english reasonably well and we don't need to download anything from HF

New deduplicate_by_lemma function handles entities that differ only in form (e.g.: "Organisationen" & "Organisation", "stores" & "store", "Fliegers" & "Flieger")
Most importantly, this also includes singular and plural. The `singularize` function is now removed

Also added function to remove leading and trailing punctuation from entities.

Tried to make `deduplicate_persons` function a little more readable