### PR TITLE
Deduplication by DPedia entity linking

### DIFF
--- a/natural_language_processing/post_process.py
+++ b/natural_language_processing/post_process.py
@@ -190,7 +190,7 @@ def dbpedia_lookup(entity_name: str, top_n: int = 5, score_threshold: int = 1000
             }
             for doc in docs
         )
-        return {doc["uri"] for doc in docs if doc["score"] > score_threshold}
+        return {doc["uri"] for doc in results if doc["score"] > score_threshold}
 
     except ValueError:
         logger.error(f"DBPedia query for {entity_name} failed: Could not parse results")

--- a/natural_language_processing/tests/conftest.py
+++ b/natural_language_processing/tests/conftest.py
@@ -5,6 +5,11 @@ from natural_language_processing.flair_ner import FlairNER
 from natural_language_processing.gliner import GLiNERModel
 
 
+@pytest.fixture
+def dbpedia_url():
+    return "https://lookup.dbpedia.org/api/search"
+
+
 @pytest.fixture(scope="session")
 def flair_model():
     yield FlairNER()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "python-dotenv",
     "gliner>=0.2.16",
     "simplemma>=1.1.2",
+    "requests-mock>=1.12.1",
 ]
 dynamic = ["version"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -659,6 +659,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
     { name = "requests" },
+    { name = "requests-mock" },
     { name = "sentencepiece" },
     { name = "simplemma" },
     { name = "torch" },
@@ -684,6 +685,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "python-dotenv" },
     { name = "requests" },
+    { name = "requests-mock", specifier = ">=1.12.1" },
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "sentencepiece" },
     { name = "simplemma", specifier = ">=1.1.2" },
@@ -1125,6 +1127,18 @@ wheels = [
 [package.optional-dependencies]
 socks = [
     { name = "pysocks" },
+]
+
+[[package]]
+name = "requests-mock"
+version = "1.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/92/32/587625f91f9a0a3d84688bf9cfc4b2480a7e8ec327cefd0ff2ac891fd2cf/requests-mock-1.12.1.tar.gz", hash = "sha256:e9e12e333b525156e82a3c852f22016b9158220d2f47454de9cae8a77d371401", size = 60901, upload-time = "2024-03-29T03:54:29.446Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/ec/889fbc557727da0c34a33850950310240f2040f3b1955175fdb2b36a8910/requests_mock-1.12.1-py2.py3-none-any.whl", hash = "sha256:b1e37054004cdd5e56c84454cc7df12b25f90f382159087f4b6915aaeef39563", size = 27695, upload-time = "2024-03-29T03:54:27.64Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add deduplication by entity linking feature to post_process.py
Instead of "true" entity linking, where different entities will be mapped to some external resource (which is very hard and atm not even that useful, since we are still searching for tags in plain-text), we settle here for deduplication.

This means, that if multiple entities are similar enough (e.g.: "US" & "USA", "FAA" & "Federal Aviation Administration") and map to the same DBPedia resource, then only the longest entity (~ the entity that carries the most information) will be kept